### PR TITLE
fix 🐛: add a svc to correct drift with source typo

### DIFF
--- a/nixosModules/ginx.nix
+++ b/nixosModules/ginx.nix
@@ -64,7 +64,7 @@ in
           ];
           wantedBy = [ "multi-user.target" ];
           serviceConfig = {
-            ExecStart = "${pkgs.bash}/bin/bash -c '${ossync}/bin/ossync";
+            ExecStart = "${pkgs.bash}/bin/bash -c '${ossync}/bin/ossync'";
             Restart = "always";
           };
         };


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
