### PR TITLE
fix 🐛 (grub): change device from /dev/disko to /dev/sda on darkness, ippo, kazuma, megumin

### DIFF
--- a/profiles/darkness/default.nix
+++ b/profiles/darkness/default.nix
@@ -29,7 +29,7 @@ in
       systemd-boot.enable = false;
       grub = {
         enable = true;
-        device = "/dev/disko";
+        device = "/dev/sda";
       };
     };
   };

--- a/profiles/ippo/default.nix
+++ b/profiles/ippo/default.nix
@@ -29,7 +29,7 @@ in
       systemd-boot.enable = false;
       grub = {
         enable = true;
-        device = "/dev/disko";
+        device = "/dev/sda";
       };
     };
   };

--- a/profiles/kazuma/default.nix
+++ b/profiles/kazuma/default.nix
@@ -29,7 +29,7 @@ in
       systemd-boot.enable = false;
       grub = {
         enable = true;
-        device = "/dev/disko";
+        device = "/dev/sda";
       };
     };
   };

--- a/profiles/megumin/default.nix
+++ b/profiles/megumin/default.nix
@@ -29,7 +29,7 @@ in
       systemd-boot.enable = false;
       grub = {
         enable = true;
-        device = "/dev/disko";
+        device = "/dev/sda";
       };
     };
   };


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
