### PR TITLE
fix 🐛 (isaac): change GRUB device from /dev/disko to /dev/sda

### DIFF
--- a/profiles/isaac/default.nix
+++ b/profiles/isaac/default.nix
@@ -64,7 +64,7 @@ in
       systemd-boot.enable = false;
       grub = {
         enable = true;
-        device = "/dev/disko";
+        device = "/dev/sda";
       };
     };
   };


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
