### PR TITLE
fix 🐛 (installer): increase sleep delay before ginx runs to allow cloud-init more time

### DIFF
--- a/installer/pre-configuration.nix
+++ b/installer/pre-configuration.nix
@@ -39,7 +39,7 @@ in
               ""
           }
                 echo Starting final configuration...
-                sleep 2
+                sleep 10
                 ginx --source https://github.com/didactiklabs/nixos-server -b main --now -- colmena apply-local --sudo
                 sudo reboot
         '';


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
