### PR TITLE
fix 🐛 (grub): use persistent disk by-id path instead of /dev/sda in GRUB config

### DIFF
--- a/profiles/darkness/default.nix
+++ b/profiles/darkness/default.nix
@@ -29,7 +29,7 @@ in
       systemd-boot.enable = false;
       grub = {
         enable = true;
-        device = "/dev/sda";
+        device = "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_drive-scsi0";
       };
     };
   };

--- a/profiles/haganezuka/default.nix
+++ b/profiles/haganezuka/default.nix
@@ -64,7 +64,7 @@ in
       systemd-boot.enable = false;
       grub = {
         enable = true;
-        device = "/dev/disko";
+        device = "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_drive-scsi0";
       };
     };
   };

--- a/profiles/kazuma/default.nix
+++ b/profiles/kazuma/default.nix
@@ -29,7 +29,7 @@ in
       systemd-boot.enable = false;
       grub = {
         enable = true;
-        device = "/dev/sda";
+        device = "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_drive-scsi0";
       };
     };
   };

--- a/profiles/megumin/default.nix
+++ b/profiles/megumin/default.nix
@@ -29,7 +29,7 @@ in
       systemd-boot.enable = false;
       grub = {
         enable = true;
-        device = "/dev/sda";
+        device = "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_drive-scsi0";
       };
     };
   };


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
